### PR TITLE
Update composables, remove unused/deprecated

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -12,34 +12,26 @@ export default defineNuxtModule<ModuleOptions>({
       nuxt: '^3.0.0'
     }
   },
-  setup (options, nuxt) {
+  setup (_options, nuxt) {
     const { resolve } = createResolver(import.meta.url)
     const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))
     nuxt.options.build.transpile.push(runtimeDir)
 
     addPlugin(resolve(runtimeDir, 'plugin'))
 
-    const composables = resolve(runtimeDir, 'composables/index')
-    addImports([
-      // Internal composables
-      { from: composables, name: 'connectModel' },
-      { from: composables, name: 'onModelReady' },
-      { from: composables, name: 'useModel' },
+    const from = resolve(runtimeDir, 'composables/index')
+    const autoImports = [
+      'createPiniaClient',
+      'defineGetters',
+      'defineSetters',
+      'defineValues',
+      'useAuth',
+      'useBackup',
+      'useDataStore',
+      'useInstanceDefaults',
+      'useServiceInstance'
+    ]
 
-      // Feathers-Pinia composables
-      { from: composables, name: 'associateGet' },
-      { from: composables, name: 'associateFind' },
-      { from: composables, name: 'feathersPiniaHooks' },
-      { from: composables, name: 'useInstanceDefaults' },
-      { from: composables, name: 'useFeathersInstance' },
-      { from: composables, name: 'useFeathersModel' },
-      { from: composables, name: 'useBaseModel' },
-      { from: composables, name: 'useService' },
-      { from: composables, name: 'useFind' },
-      { from: composables, name: 'useGet' },
-      { from: composables, name: 'useAuth' },
-      { from: composables, name: 'useClone' },
-      { from: composables, name: 'useClones' }
-    ])
+    addImports(autoImports.map(name => ({ from, name })))
   }
 })

--- a/src/runtime/composables/index.ts
+++ b/src/runtime/composables/index.ts
@@ -1,9 +1,11 @@
 export {
-  useInstanceDefaults,
-  useDataStore,
-  useAuth,
   createPiniaClient,
   defineValues,
   defineGetters,
-  defineSetters
+  defineSetters,
+  useAuth,
+  useBackup,
+  useDataStore,
+  useInstanceDefaults,
+  useServiceInstance
 } from 'feathers-pinia'


### PR DESCRIPTION
Replace unused internal composables and deprecated ones with those specified in the [unplugin-auto-import-preset.ts](https://github.com/marshallswain/feathers-pinia/blob/main/src/unplugin-auto-import-preset.ts).

I tried using `feathersPiniaAutoImport` in `modules.ts` but ran into the same issue (#1) as in other nuxt apps when trying to load the `feathers-pinia` package from node_modules.